### PR TITLE
Signatures in messagesigner.cpp using old message format while fork i…

### DIFF
--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -79,16 +79,30 @@ bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std
 
 bool CSignedMessage::Sign(const CKey& key, const CPubKey& pubKey)
 {
-    nMessVersion = MessageVersion::MESS_VER_HASH;
     std::string strError = "";
-    uint256 hash = GetSignatureHash();
 
-    if(!CHashSigner::SignHash(hash, key, vchSig)) {
-        return error("%s : SignHash() failed", __func__);
-    }
+    if(Params().GetConsensus().NetworkUpgradeActive(chainActive.Height(), Consensus::UPGRADE_POS_V2)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
+        uint256 hash = GetSignatureHash();
 
-    if (!CHashSigner::VerifyHash(hash, pubKey, vchSig, strError)) {
-        return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        if (!CHashSigner::SignHash(hash, key, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKey, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
+            return error("%s : SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKey, vchSig, strMessage, strError)) {
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;


### PR DESCRIPTION
This small patch makes sure the masternode sends out the ping in the old message format before the fork so old clients understand it.